### PR TITLE
Add release build copying for dist assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+release/

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.0",
   "description": "Manage reusable content blocks for Obsidian",
   "scripts": {
-    "build": "rollup -c"
+    "build": "rollup -c",
+    "release": "npm run build && node release.js"
   },
   "devDependencies": {
     "obsidian": "^1.0.0",

--- a/release.js
+++ b/release.js
@@ -1,0 +1,30 @@
+const fs = require('fs');
+const path = require('path');
+
+const releaseDir = path.join(__dirname, 'release');
+
+if (fs.existsSync(releaseDir)) {
+  fs.rmSync(releaseDir, { recursive: true, force: true });
+}
+fs.mkdirSync(releaseDir);
+
+const files = [
+  ['dist/main.js', 'main.js'],
+  ['dist/styles.css', 'styles.css'],
+  ['manifest.json', 'manifest.json']
+];
+
+for (const [src, dest] of files) {
+  const srcPath = path.join(__dirname, src);
+  const destPath = path.join(releaseDir, dest);
+  fs.copyFileSync(srcPath, destPath);
+}
+
+const expected = new Set(files.map(f => f[1]));
+const actual = fs.readdirSync(releaseDir);
+
+if (actual.length !== expected.size || !actual.every(f => expected.has(f))) {
+  throw new Error('Release directory does not contain the expected files.');
+}
+
+console.log('Release files prepared:', actual.join(', '));


### PR DESCRIPTION
## Summary
- add release.js to copy built files to a `release/` folder
- ignore `release/` in version control
- add `npm run release` script to package.json


