### PR TITLE
Add community plugin submission guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,14 @@ npm run build
 ```
 
 Copy the `dist/` folder to your vault's `.obsidian/plugins/vault-note-blocks` directory.
+
+## Community Plugin Submission
+
+If you want this plugin listed in Obsidian's community catalog:
+
+1. Run `npm run release` and create a GitHub release with the files from the `release/` folder.
+2. Fork [`obsidianmd/obsidian-releases`](https://github.com/obsidianmd/obsidian-releases).
+3. Append `"vault-note-blocks"` to the end of `community-plugins.json`.
+4. Open a pull request describing your plugin and include the repository URL `PtiCalin/vault_note-blocks`.
+
+Your release must contain a `manifest.json` matching the plugin `id`, `name`, and `version` found in this repo.


### PR DESCRIPTION
## Summary
- add details about submitting the plugin to obsidianmd/obsidian-releases

## Testing
- `npm run build` *(fails: rollup not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6845d2f5f81483229febe3f0b2cdef0c