### PR TITLE
Add versions.json with compatibility info

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,5 @@ If you want this plugin listed in Obsidian's community catalog:
 4. Open a pull request describing your plugin and include the repository URL `PtiCalin/vault_note-blocks`.
 
 Your release must contain a `manifest.json` matching the plugin `id`, `name`, and `version` found in this repo.
+
+Compatibility information is tracked in `versions.json`. Remember to update this file along with `manifest.json` whenever you cut a new release.

--- a/versions.json
+++ b/versions.json
@@ -1,0 +1,5 @@
+{
+  "plugin-version": "0.1.0",
+  "obsidian-min": "0.15.0",
+  "obsidian-max": "1.0.0"
+}


### PR DESCRIPTION
## Summary
- track plugin version compatibility in `versions.json`
- mention the file in the README so maintainers update it during releases

## Testing
- `npm run build` *(fails: rollup not found)*
- `npm install` *(fails: unable to reach npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_6845d39bd8808322bbe1a0e4c8e845c5